### PR TITLE
Add support for split cert/key deployment

### DIFF
--- a/cmd/dotege/config.go
+++ b/cmd/dotege/config.go
@@ -51,6 +51,7 @@ const (
 
 const (
 	CertificateDeploymentCombined = "combined"
+	CertificateDeploymentSplit    = "splitkeys"
 	CertificateDeploymentDisabled = "disabled"
 )
 


### PR DESCRIPTION
There's some code duplication that could probably be removed.
Maybe the logic could better, doesn't redeploy key if cert is the same, can't decide if this is an issue?